### PR TITLE
Установка текущей страницы в заметках на 0

### DIFF
--- a/internal/bot/view/note.go
+++ b/internal/bot/view/note.go
@@ -63,6 +63,8 @@ func (v *NoteView) Message(notes []model.Note) string {
 		v.pages = append(v.pages, res)
 	}
 
+	v.currentPage = 0
+
 	return v.pages[0]
 }
 


### PR DESCRIPTION
Теперь при составлении первой страницы заметок во `view` текущая страница устанавливается в 0. Когда этого не было, был баг, что бот падал с `nil ptr`, потому что страница могла быть установлена в 3, а пользователь уже удалил какое-то кол-во заметок и такой страницы больше нет