### PR TITLE
Баг с поиском заметок

### DIFF
--- a/internal/bot/fsm/search_note_by_text.go
+++ b/internal/bot/fsm/search_note_by_text.go
@@ -30,7 +30,14 @@ func (n *searchNoteByTextState) Handle(ctx context.Context, telectx tele.Context
 		return n.controller.DeleteNoteByID(ctx, telectx)
 	}
 
-	return n.controller.SearchNoteByText(ctx, telectx)
+	err := n.controller.SearchNoteByText(ctx, telectx)
+	if err != nil {
+		return err
+	}
+
+	n.fsm.SetNext()
+
+	return nil
 }
 
 func (n *searchNoteByTextState) Name() string {


### PR DESCRIPTION
Исправлен баг при поиске заметок по тексту: теперь бот после успешной процедуры поиска сохраняет текст, который ему прислали после этого, рассматривая его как заметку